### PR TITLE
First round of Python3 compatibility

### DIFF
--- a/scripts/map_SNP_positions.py
+++ b/scripts/map_SNP_positions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from argparse import ArgumentParser
 import os
 import gzip
@@ -59,7 +60,7 @@ def select_snps(mirna, snp, out):
     Use bedtools to intersect coordinates
     """
     with open(out, 'w') as out_handle:
-        print >>out_handle, _create_header(mirna, snp, out)
+        print(_create_header(mirna, snp, out), file=out_handle, end="")
         snp_in_mirna = pybedtools.BedTool(snp).intersect(pybedtools.BedTool(mirna), wo=True)
         for single in snp_in_mirna:
             if single[10] == "miRNA" and len(single[3]) + len(single[4]) == 2:
@@ -73,7 +74,7 @@ def select_snps(mirna, snp, out):
                 line.append(single[5])
                 line.append(single[6])
                 line.append(single[7])
-                print >>out_handle, "\t".join(line)
+                print("\t".join(line), file=out_handle, end="")
     return out
 
 if __name__ == "__main__":
@@ -84,4 +85,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     mirna_snp = select_snps(args.gtf, args.vcf, args.out)
-    print "%s mapped to %s: %s" % (args.vcf, args.gtf, mirna_snp)
+    print("%s mapped to %s: %s" % (args.vcf, args.gtf, mirna_snp))

--- a/scripts/miRNA.simulator.py
+++ b/scripts/miRNA.simulator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from optparse import OptionParser
 import sys
 import os
@@ -34,9 +35,9 @@ class mirna:
 		self.p5=0
 		self.p3=0
 	def addp5(self,n,s,e):
-		#print "adding p5"
+		#print("adding p5")
 		self.p5=pos(n,s,e)
-		#print self.p5
+		#print(self.p5)
 	def addp3(self,n,s,e):
 		self.p3=pos(n,s,e)
 
@@ -129,11 +130,11 @@ for line in fas:
                                                 trial =random.randint(1, 100)
                                                 p = random.randint(1, 50) / 50.0
                                                 exp = "_x%s" % numpy.random.negative_binomial(trial, p, 1)[0]
-                                            print >>fqout, "@%s%s" % (randName, exp)
-                                            print >>fqout, "%s" % randSeq
-                                            print >>fqout, "+\n%s" % "".join(["I"] * len(randSeq))
-                                            print >>fout, ">%s%s" % (randName, exp)
-                                            print >>fout, "%s" % randSeq
+                                            print("@%s%s" % (randName, exp), file=fqout, end="")
+                                            print("%s" % randSeq, file=fqout, end="")
+                                            print("+\n%s" % "".join(["I"] * len(randSeq)), file=fqout, end="")
+                                            print(">%s%s" % (randName, exp), file=fout, end="")
+                                            print("%s" % randSeq, file=fout, end="")
                                             data[randSeq]=1
                 name = line.split(" ")
                 name = name[0].replace(">","")

--- a/seqcluster/detect/description.py
+++ b/seqcluster/detect/description.py
@@ -15,7 +15,10 @@ def sort_precursor(c, loci):
     """
     Sort loci according to number of sequences mapped there.
     """
-    data_loci = map(lambda (x): [x, loci[x].chr, int(loci[x].start), int(loci[x].end), loci[x].strand, len(c.loci2seq[x])], c.loci2seq.keys())
+    # Original Py 2.7 code
+    #data_loci = map(lambda (x): [x, loci[x].chr, int(loci[x].start), int(loci[x].end), loci[x].strand, len(c.loci2seq[x])], c.loci2seq.keys())
+    # 2to3 suggested Py 3 rewrite
+    data_loci = [[x, loci[x].chr, int(loci[x].start), int(loci[x].end), loci[x].strand, len(c.loci2seq[x])] for x in list(c.loci2seq.keys())]
     data_loci = sorted(data_loci, key=itemgetter(5), reverse=True)
     return data_loci
 

--- a/seqcluster/detect/metacluster.py
+++ b/seqcluster/detect/metacluster.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from collections import defaultdict
 import operator
 import os
@@ -99,7 +100,7 @@ def _write_cluster(metacluster, cluster, loci, idx, path):
             for idc in metacluster:
                 for idl in cluster[idc].loci2seq:
                     pos = loci[idl].list()
-                    print >>out_handle, "\t".join(pos[:4] + [str(len(cluster[idc].loci2seq[idl]))] + [pos[-1]])
+                    print("\t".join(pos[:4] + [str(len(cluster[idc].loci2seq[idl]))] + [pos[-1]]), file=out_handle, end="")
 
 
 def _add_complete_cluster(idx, meta, clusters):

--- a/seqcluster/explore_cluster.py
+++ b/seqcluster/explore_cluster.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #import sys
 import os
 #from os import listdir
@@ -20,7 +21,7 @@ def explore(args):
     seqs, names = get_sequences_from_cluster(c1, c2, data[0])
     loci = get_precursors_from_cluster(c1, c2, data[0])
     logger.info("map all sequences to all loci")
-    print "%s" % (loci)
+    print("%s" % (loci))
     map_to_precursors(seqs, names, loci, os.path.join(args.out, "map.tsv"), args)
     #map_sequences_w_bowtie(sequences, precursors)
     logger.info("plot sequences on loci")

--- a/seqcluster/function/coral.py
+++ b/seqcluster/function/coral.py
@@ -1,4 +1,5 @@
 """prepare data for CoRaL"""
+from __future__ import print_function
 import os.path as op
 from collections import Counter
 import pybedtools
@@ -47,7 +48,7 @@ def _reorder_columns(bed_file):
                 cols = line.strip().split("\t")
                 cols[3] = _select_anno(cols[3]) + "_" + cols[4]
                 cols[4] = "0"
-                print >>out_handle, "\t".join(cols)
+                print("\t".join(cols), file=out_handle, end="")
     return new_bed
 
 
@@ -61,7 +62,7 @@ def _fix_score_column(cov_file):
             for line in in_handle:
                 cols = line.strip().split("\t")
                 cols[4] = cols[6]
-                print >>out_handle, "\t".join(cols[0:6])
+                print("\t".join(cols[0:6]), file=out_handle, end="")
     return new_cov
 
 
@@ -87,11 +88,11 @@ def _order_antisense_column(cov_file, min_reads):
     new_cov = op.join(op.dirname(cov_file), 'feat_antisense.txt')
     with open(cov_file) as in_handle:
         with open(new_cov, 'w') as out_handle:
-            print >>out_handle, "name\tantisense"
+            print("name\tantisense", file=out_handle, end="")
             for line in in_handle:
                 cols = line.strip().split("\t")
                 cols[6] = 0 if cols[6] < min_reads else cols[6]
-                print >>out_handle, "%s\t%s" % (cols[3], cols[6])
+                print("%s\t%s" % (cols[3], cols[6]), file=out_handle, end="")
     return new_cov
 
 
@@ -114,7 +115,7 @@ def _reads_per_position(bam_in, loci_file, out_dir):
     counts_reads = op.join(out_dir, 'locus_readpos.counts')
     with open(counts_reads, 'w') as out_handle:
         for k in data:
-            print >>out_handle, k
+            print(k, file=out_handle, end="")
 
     return counts_reads
 

--- a/seqcluster/function/target.py
+++ b/seqcluster/function/target.py
@@ -1,4 +1,5 @@
 """Get enrichment of targets doing permutations for significance"""
+from __future__ import print_function
 import os.path as op
 from collections import defaultdict
 import gzip
@@ -46,15 +47,15 @@ def targets_enrichment(args):
                 name = cols[0].split(".")[0]
                 res[(name, 'info')] = line.strip()
                 res[(name, 'mirs')].append(mir)
-                print >>ma_handle, "%s\t%s\t%s" % (name, mir, sorted_targets[e]['score'])
+                print("%s\t%s\t%s" % (name, mir, sorted_targets[e]['score']), file=ma_handle, end="")
 
     with open(op.join(args.out, "pairs.tsv"), 'w') as out_handle:
-        print >>out_handle, "mirs\tcounts\tgene\ttranscript\tgene\tsites\tcontext_score\tAggr_PCT"
+        print("mirs\tcounts\tgene\ttranscript\tgene\tsites\tcontext_score\tAggr_PCT",file=out_handle, end="")
         for gene, field in res:
             if field == "info":
                 counts = len(res[(gene, 'mirs')])
                 mirs = ",".join(list(set(res[(gene, 'mirs')])))
-                print >>out_handle, "%s\t%s\t%s\t%s" %  (mirs, counts,  gene, res[(gene, 'info')])
+                print("%s\t%s\t%s\t%s" %  (mirs, counts,  gene, res[(gene, 'info')]), file=out_handle, end="")
 
 
 def _get_mirna_input(fn):

--- a/seqcluster/html/HTML.py
+++ b/seqcluster/html/HTML.py
@@ -12,6 +12,8 @@ License: CeCILL (open-source GPL compatible), see source code for details.
          http://www.cecill.info
 """
 
+from __future__ import print_function
+
 __version__ = '0.04'
 __date__    = '2009-07-28'
 __author__  = 'Philippe Lagadec'
@@ -61,6 +63,7 @@ __author__  = 'Philippe Lagadec'
 # 2009-07-21 v0.03 PL: - added column attributes and styles (first attempt)
 #                        (thanks to an idea submitted by Michal Cernoevic)
 # 2009-07-28 v0.04 PL: - improved column styles, workaround for Mozilla
+# 2018-07-10           - Python 3 compatibility
 
 
 #-------------------------------------------------------------------------------
@@ -436,8 +439,8 @@ if __name__ == '__main__':
     t.rows.append(TableRow(['D', 'E', 'F']))
     t.rows.append(('i', 'j', 'k'))
     f.write(str(t) + '<p>\n')
-    print str(t)
-    print '-'*79
+    print(str(t))
+    print('-'*79)
 
     t2 = Table([
             ('1', '2'),
@@ -445,15 +448,15 @@ if __name__ == '__main__':
         ], width='100%', header_row=('col1', 'col2'),
         col_width=('', '75%'))
     f.write(str(t2) + '<p>\n')
-    print t2
-    print '-'*79
+    print(t2)
+    print('-'*79)
 
     t2.rows.append(['5', '6'])
     t2.rows[1][1] = TableCell('new', bgcolor='red')
     t2.rows.append(TableRow(['7', '8'], attribs={'align': 'center'}))
     f.write(str(t2) + '<p>\n')
-    print t2
-    print '-'*79
+    print(t2)
+    print('-'*79)
 
     # sample table with column attributes and styles:
     table_data = [
@@ -467,8 +470,8 @@ if __name__ == '__main__':
         col_align=['left', 'center', 'right', 'char'],
         col_styles=['font-size: large', '', 'font-size: small', 'background-color:yellow'])
     f.write(htmlcode + '<p>\n')
-    print htmlcode
-    print '-'*79
+    print(htmlcode)
+    print('-'*79)
 
     def gen_table_squares(n):
         """
@@ -483,7 +486,7 @@ if __name__ == '__main__':
     t = Table(rows=gen_table_squares(10), header_row=('x', 'square(x)'))
     f.write(str(t) + '<p>\n')
 
-    print '-'*79
+    print('-'*79)
     l = List(['aaa', 'bbb', 'ccc'])
     f.write(str(l) + '<p>\n')
     l.ordered = True

--- a/seqcluster/libs/annotation.py
+++ b/seqcluster/libs/annotation.py
@@ -25,7 +25,7 @@ def read_gtf_line(cols, field="name"):
         e = int(cols[4])
         st = cols[6]
         return [c, s, e, st, group, name[0]]
-    except Exception, e:
+    except(Exception, e):
         logger.error(cols)
         logger.error("File is not in correct format")
         logger.error("Expect chr source feature start end . strand attributes")

--- a/seqcluster/libs/parse.py
+++ b/seqcluster/libs/parse.py
@@ -1,9 +1,9 @@
+from __future__ import print_function
 import argparse
 import sys
 
-
 def parse_cl(in_args):
-    print in_args
+    print(in_args)
     sub_cmds = {"prepare": add_subparser_prepare,
                 "cluster": add_subparser_cluster,
                 "seqbuster": add_subparser_mirbuster,
@@ -21,7 +21,7 @@ def parse_cl(in_args):
         sub_cmds[in_args[0]](subparsers)
         sub_cmd = in_args[0]
     else:
-        print "use %s" % sub_cmds.keys()
+        print("use %s" % sub_cmds.keys())
         sys.exit(0)
     args = parser.parse_args()
 

--- a/seqcluster/libs/report.py
+++ b/seqcluster/libs/report.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import logging
 import string
 import os
@@ -87,7 +88,7 @@ def _convert_to_df(in_file, freq, raw_file):
         for name in in_file:
             counts = freq[name]
             if raw_file:
-                print >>out_handle, "%s\t%s\t%s\t%s\t%s\t%s" % ("chr", in_file[name][0], in_file[name][1], name, sum(counts.values()), "+")
+                print("%s\t%s\t%s\t%s\t%s\t%s" % ("chr", in_file[name][0], in_file[name][1], name, sum(counts.values()), "+"), file=out_handle, end="")
             dat = _expand(dat, counts, in_file[name][0], in_file[name][1])
 
     for s in dat:

--- a/seqcluster/libs/simulator.py
+++ b/seqcluster/libs/simulator.py
@@ -1,4 +1,5 @@
 """simulate cluster over the genome"""
+from __future__ import print_function
 import random
 from read import get_fasta
 
@@ -74,14 +75,14 @@ def _write_reads(reads, prefix):
     out_fasta = prefix + ".fasta"
     out_real = prefix + ".txt"
     with open(out_ma, 'w') as ma_handle:
-        print >>ma_handle, "id\tseq\tsample"
+        print("id\tseq\tsample", file=ma_handle, end="")
         with open(out_fasta, 'w') as fa_handle:
             with open(out_real, 'w') as read_handle:
                 for idx, r in enumerate(reads):
                     info = r.split("_")
-                    print >>ma_handle, "seq_%s\t%s\t%s" % (idx, reads[r][0], reads[r][1])
-                    print >>fa_handle, ">seq_%s\n%s" % (idx, reads[r][0])
-                    print >>read_handle, "%s\t%s\t%s\t%s\t%s\t%s\t%s" % (idx, r, reads[r][0], reads[r][1], info[1], info[2], info[3])
+                    print("seq_%s\t%s\t%s" % (idx, reads[r][0], reads[r][1]), file=ma_handle, end="")
+                    print(">seq_%s\n%s" % (idx, reads[r][0]), file=fa_handle, end="")
+                    print("%s\t%s\t%s\t%s\t%s\t%s\t%s" % (idx, r, reads[r][0], reads[r][1], info[1], info[2], info[3]), file=read_handle, end="")
 
 
 def _get_precursor(bed_file, reference, out_fa):

--- a/seqcluster/libs/thinkbayes.py
+++ b/seqcluster/libs/thinkbayes.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """This file contains code for use with "Think Bayes",
 by Allen B. Downey, available from greenteapress.com
 
@@ -286,7 +288,7 @@ class _DictWrapper(object):
     def Print(self):
         """Prints the values and freqs/probs in ascending order."""
         for val, prob in sorted(self.d.iteritems()):
-            print val, prob
+            print(val, prob)
 
     def Set(self, x, y=0):
         """Sets the freq/prob associated with the value x.
@@ -1226,7 +1228,7 @@ class Suite(Pmf):
     def Print(self):
         """Prints the hypotheses and their probabilities."""
         for hypo, prob in sorted(self.Items()):
-            print hypo, prob
+            print(hypo, prob)
 
     def MakeOdds(self):
         """Transforms from probabilities to odds.

--- a/seqcluster/libs/tool.py
+++ b/seqcluster/libs/tool.py
@@ -37,7 +37,7 @@ def calc_complexity(nl):
     total = 0.0
     for l in nl:
         total += 1.0/l
-        #print total
+        #print(total)
     total /= ns
     return (total)
 

--- a/seqcluster/make_clusters.py
+++ b/seqcluster/make_clusters.py
@@ -165,18 +165,24 @@ def _write_size_table(data_freq, data_len, ann_valid, cluster_id):
         table += "%s\t%s\t%s\t%s\n" % (l, dd[l], ann_valid, cluster_id)
     return table
 
-
 def _get_annotation(c, loci):
     """get annotation of transcriptional units"""
     data_ann_temp = {}
     data_ann = []
     counts = Counter()
     for lid in c.loci2seq:
-        for dbi in loci[lid].db_ann.keys():
-            data_ann_temp[dbi] = {dbi: map(lambda (x): loci[lid].db_ann[dbi].ann[x].name, loci[lid].db_ann[dbi].ann.keys())}
+        # original Py 2.7 code
+        #for dbi in loci[lid].db_ann.keys():
+        #    data_ann_temp[dbi] = {dbi: map(lambda (x): loci[lid].db_ann[dbi].ann[x].name, loci[lid].db_ann[dbi].ann.keys())}
+        # suggestion by 2to3
+        for dbi in list(loci[lid].db_ann.keys()):
+            data_ann_temp[dbi] = {dbi: [loci[lid].db_ann[dbi].ann[x].name for x in list(loci[lid].db_ann[dbi].ann.keys())]}
             logger.debug("_json_: data_ann_temp %s %s" % (dbi, data_ann_temp[dbi]))
             counts[dbi] += 1
-        data_ann = data_ann + map(lambda (x): data_ann_temp[x], data_ann_temp.keys())
+        # original Py 2.7 code
+        #data_ann = data_ann + map(lambda (x): data_ann_temp[x], data_ann_temp.keys())
+        # suggestion by 2to3
+        data_ann = data_ann + [data_ann_temp[x] for x in list(data_ann_temp.keys())]
         logger.debug("_json_: data_ann %s" % data_ann)
     counts = {k: v for k, v in counts.iteritems()}
     total_loci = sum([counts[db] for db in counts])
@@ -315,11 +321,20 @@ def _create_json(clusL, args):
             bed_line = "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" % (chrom, s, e, annotation, cid, st, len(seqList))
             out_bed.write(bed_line)
 
-            data_seqs = map(lambda (x): {x: seqs[x].seq}, seqList)
+            # original Py 2.7 code
+            #data_seqs = map(lambda (x): {x: seqs[x].seq}, seqList)
+            # proposal by 2to3
+            data_seqs = [{x: seqs[x].seq} for x in seqList]
             scaled_seqs = _get_counts(seqList, seqs, c.idmembers)
-            data_freq = map(lambda (x): scaled_seqs[x].freq, seqList)
-            data_freq_w_id = map(lambda (x): {x: scaled_seqs[x].norm_freq}, seqList)
-            data_len = map(lambda (x): seqs[x].len, seqList)
+            # original Py 2.7 code
+            #data_freq = map(lambda (x): scaled_seqs[x].freq, seqList)
+            #data_freq_w_id = map(lambda (x): {x: scaled_seqs[x].norm_freq}, seqList)
+            #data_len = map(lambda (x): seqs[x].len, seqList)
+            # proposal by 2to3
+            data_freq = [scaled_seqs[x].freq for x in seqList]
+            data_freq_w_id = [{x: scaled_seqs[x].norm_freq} for x in seqList]
+            data_len = [seqs[x].len for x in seqList]
+
             sum_freq = _sum_by_samples(scaled_seqs, samples_order)
 
             data_ann_str = [["%s::%s" % (name, ",".join(features)) for name, features in k.iteritems()] for k in data_ann]

--- a/seqcluster/make_clusters.py
+++ b/seqcluster/make_clusters.py
@@ -330,7 +330,7 @@ def _create_json(clusL, args):
                 if f.count(0) > 0.1 * len(f) and len(f) > 9:
                     continue
                 f = map(str, f)
-                print >>matrix_single, "\t".join([str(cid), data_valid_str, seqs[s].seq, "\t".join(f)])
+                print("\t".join([str(cid), data_valid_str, seqs[s].seq, "\t".join(f)]), file=matrix_single, end="")
 
             matrix.write("%s\t%s\t%s|%s\t%s\n" % (cid, c.toomany, data_valid_str, ";".join([";".join(d) for d in data_ann_str]), "\t".join(map(str, sum_freq))))
             size_matrix.write(_write_size_table(data_freq, data_len, data_valid_str, cid))

--- a/seqcluster/make_clusters.py
+++ b/seqcluster/make_clusters.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import os.path as op

--- a/seqcluster/prepare_data.py
+++ b/seqcluster/prepare_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #import sys
 import os
 import os.path as op
@@ -128,8 +129,8 @@ def _read_fastq_files(f, args):
                                 seq_l[seq] = sequence_unique(idx, seq)
                             seq_l[seq].add_exp(cols[1], counts)
                             seq_l[seq].quality = keep[seq].get()
-                print >>out_handle, "total\t%s\t%s" % (idx, cols[1])
-                print >>out_handle, "added\t%s\t%s" % (len(seq_l), cols[1])
+                print("total\t%s\t%s" % (idx, cols[1]), file=out_handle, end="")
+                print("added\t%s\t%s" % (len(seq_l), cols[1]), file=out_handle, end="")
                 logger.info("%s: Total read %s ; Total added %s" % (cols[1], idx, len(seq_l)))
     return seq_l, sample_l
 

--- a/seqcluster/seqbuster/__init__.py
+++ b/seqcluster/seqbuster/__init__.py
@@ -1,4 +1,5 @@
 # Re-aligner small RNA sequence from SAM/BAM file (miRBase annotation)
+from __future__ import print_function
 import traceback
 import os.path as op
 import re

--- a/seqcluster/seqbuster/__init__.py
+++ b/seqcluster/seqbuster/__init__.py
@@ -55,8 +55,8 @@ def _filter_seqs(fn):
                         counts = _get_freq(fixed_name)
                         if len(seq) < 26 and (counts > 1 or counts == 0):
                             idx += 1
-                            print >>out_handle, fixed_name
-                            print >>out_handle, seq
+                            print(fixed_name, file=out_handle, end="")
+                            print(seq, file=out_handle, end="")
                         try:
                             if line.startswith("@"):
                                 in_handle.next()
@@ -81,8 +81,8 @@ def _convert_to_fasta(fn):
                 if line.find("_x"):
                     count = int(line.strip().split("_x")[1])
                 if count > 1:
-                    print >>out_handle, ">%s" % line.strip()[1:]
-                    print >>out_handle, seq.strip()
+                    print(">%s" % line.strip()[1:], file=out_handle, end="")
+                    print(seq.strip(), file=out_handle, end="")
     return out_file
 
 def _get_pos(string):
@@ -263,7 +263,7 @@ def _read_bam(bam_fn, precursors):
     reads = defaultdict(realign)
     for line in handle:
         chrom = handle.getrname(line.reference_id)
-        # print "%s %s %s %s" % (line.query_name, line.reference_start, line.query_sequence, chrom)
+        # print("%s %s %s %s" % (line.query_name, line.reference_start, line.query_sequence, chrom))
         query_name = line.query_name
         if query_name not in reads:
             reads[query_name].sequence = line.query_sequence
@@ -286,7 +286,7 @@ def _read_pyMatch(fn, precursors):
             query_name, seq, chrom, reference_start, end, mism, add = line.split()
             reference_start = int(reference_start)
             # chrom = handle.getrname(cols[1])
-            # print "%s %s %s %s" % (line.query_name, line.reference_start, line.query_sequence, chrom)
+            # print("%s %s %s %s" % (line.query_name, line.reference_start, line.query_sequence, chrom))
             if query_name not in reads:
                 reads[query_name].sequence = seq
             iso = isomir()
@@ -360,7 +360,7 @@ def _tab_output(reads, out_file, sample):
     seen_ann = {}
     dt = None
     with open(out_file, 'w') as out_handle:
-        print >>out_handle, "name\tseq\tfreq\tchrom\tstart\tend\tsubs\tadd\tt5\tt3\ts5\ts3\tDB\tprecursor\thits"
+        print("name\tseq\tfreq\tchrom\tstart\tend\tsubs\tadd\tt5\tt3\ts5\ts3\tDB\tprecursor\thits", file=out_handle, end="")
         for r, read in reads.iteritems():
             hits = set()
             [hits.add(mature.mirna) for mature in read.precursors.values() if mature.mirna]
@@ -386,7 +386,7 @@ def _tab_output(reads, out_file, sample):
                     seen_ann[annotation] = res
                     lines.append([annotation, chrom, count, sample, hits])
                     lines_pre.append([annotation, chrom, p, count, sample, hits])
-                    print >>out_handle, res
+                    print(res, file=out_handle, end="")
 
     if lines:
         dt = pd.DataFrame(lines)
@@ -485,4 +485,4 @@ def miraligner(args):
         _create_counts(out_dts, args.out)
         # _summarize(out_dts)
     else:
-        print "No files analyzed!"
+        print("No files analyzed!")

--- a/seqcluster/seqbuster/snps.py
+++ b/seqcluster/seqbuster/snps.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 
 import seqcluster.libs.logger as mylog
@@ -31,8 +33,8 @@ def _get_reference_position(isomir):
         off = len(trim5)
     if trim5 == "NA" or trim5 == "0":
         off = 0
-    # print isomir
-    # print [mut, pos, off, nt]
+    # print(isomir)
+    # print([mut, pos, off, nt])
     return "%s%s" % (pos + off, nt)
 
 def _get_pct(isomirs, mirna):
@@ -64,16 +66,16 @@ def _print_header(data):
     Create vcf header to make
     a valid vcf.
     """
-    print >>STDOUT, "##fileformat=VCFv4.2"
-    print >>STDOUT, "##source=seqbuster2.3"
-    print >>STDOUT, "##reference=mirbase"
+    print("##fileformat=VCFv4.2", file=STDOUT, end="")
+    print("##source=seqbuster2.3", file=STDOUT, end="")
+    print("##reference=mirbase", file=STDOUT, end="")
     for pos in data:
-        print >>STDOUT, "##contig=<ID=%s>" % pos["chrom"]
-    print >>STDOUT, '##INFO=<ID=ID,Number=1,Type=String,Description="miRNA name">'
-    print >>STDOUT, '##FORMAT=<ID=GT,Number=1,Type=Integer,Description="Genotype">'
-    print >>STDOUT, '##FORMAT=<ID=NR,Number=A,Type=Integer,Description="Total reads supporting the variant">'
-    print >>STDOUT, '##FORMAT=<ID=NS,Number=A,Type=Float,Description="Total number of different sequences supporting the variant">'
-    print >>STDOUT, "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMP001"
+        print("##contig=<ID=%s>" % pos["chrom"], file=STDOUT, end="")
+    print('##INFO=<ID=ID,Number=1,Type=String,Description="miRNA name">', file=STDOUT, end="")
+    print('##FORMAT=<ID=GT,Number=1,Type=Integer,Description="Genotype">', file=STDOUT, end="")
+    print('##FORMAT=<ID=NR,Number=A,Type=Integer,Description="Total reads supporting the variant">', file=STDOUT, end="")
+    print('##FORMAT=<ID=NS,Number=A,Type=Float,Description="Total number of different sequences supporting the variant">', file=STDOUT, end="")
+    print("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMP001", file=STDOUT, end="")
 
 def print_vcf(data):
     """Print vcf line following rules."""
@@ -87,7 +89,7 @@ def print_vcf(data):
     info = "ID=%s" % data['mature']
     frmt = "GT:NR:NS"
     gntp = "%s:%s:%s" % (_genotype(data), data["counts"], data["diff"])
-    print >>STDOUT, "\t".join(map(str, [chrom, pos, id_name, nt_ref, nt_snp, qual, flt, info, frmt, gntp]))
+    print("\t".join(map(str, [chrom, pos, id_name, nt_ref, nt_snp, qual, flt, info, frmt, gntp])), file=STDOUT, end="")
 
 def _make_header():
     """
@@ -102,7 +104,7 @@ def liftover(pass_pos, matures):
         mir = pos["mature"]
         db_pos = matures[pos["chrom"]]
         mut = _parse_mut(pos["sv"])
-        print [db_pos[mir], mut, pos["sv"]]
+        print([db_pos[mir], mut, pos["sv"]])
         pos['pre_pos'] = db_pos[mir][0] + mut[1] - 1
         pos['nt'] = list(mut[0])
         fixed_pos.append(pos)
@@ -141,7 +143,7 @@ def liftover_to_genome(pass_pos, gtf):
             continue
         db_pos = gtf[pos["chrom"]][0]
         mut = _parse_mut(pos["sv"])
-        print [db_pos, pos]
+        print([db_pos, pos])
         if db_pos[3] == "+":
             pos['pre_pos'] = db_pos[1] + pos["pre_pos"] + 1
         else:

--- a/seqcluster/stats.py
+++ b/seqcluster/stats.py
@@ -38,8 +38,12 @@ def _read_json(fn_json):
     is_db = {}
     with open(fn_json) as handle:
         data = json.load(handle)
-        for item in data[0].values():
-            seqs_name = map(lambda (x): x.keys(), item['seqs'])
+        # original Py 2.y core
+        #for item in data[0].values():
+        #    seqs_name = map(lambda (x): x.keys(), item['seqs'])
+        # rewrite by 2to3
+        for item in list(data[0].values()):
+            seqs_name = [list(x.keys()) for x in item['seqs']]
             db_name = item['valid'] if "valid" in item else None
             [is_json.add(name[0]) for name in seqs_name]
             if db_name:

--- a/test/test_automated_analysis.py
+++ b/test/test_automated_analysis.py
@@ -2,6 +2,7 @@
 
 Inspired in bcbio-nextgen code
 """
+from __future__ import print_function
 import os
 import subprocess
 import unittest
@@ -56,7 +57,7 @@ class AutomatedAnalysisTest(unittest.TestCase):
         #       self._download_to_dir(url, dirname)
 
     def _download_to_dir(self, url, dirname):
-        print dirname
+        print(dirname)
         cl = ["wget", url]
         subprocess.check_call(cl)
         cl = ["tar", "-xzvpf", os.path.basename(url)]
@@ -77,14 +78,14 @@ class AutomatedAnalysisTest(unittest.TestCase):
                   "--gtf", "../../data/examples/cluster/ann_reduced.gtf",
                   "-r", "../../data/genomes/genome.fa",
                   "-o", "test_out_res"]
-            print " ".join(cl)
+            print(" ".join(cl))
             subprocess.check_call(cl)
             cl = ["seqcluster",
                   "report",
                   "-j", "test_out_res/seqcluster.json",
                   "-r", "../../data/genomes/genome.fa",
                   "-o", "test_out_report"]
-            print " ".join(cl)
+            print(" ".join(cl))
             subprocess.check_call(cl)
 
     @attr(complete=True)
@@ -100,7 +101,7 @@ class AutomatedAnalysisTest(unittest.TestCase):
                   "--mirna", "../../data/examples/miraligner/miRNA.str",
                   "-o", "test_out_mirs_fasta",
                   "../../data/examples/miraligner/sim_isomir.fa"]
-            print " ".join(cl)
+            print(" ".join(cl))
             subprocess.check_call(cl)
 
 
@@ -117,6 +118,6 @@ class AutomatedAnalysisTest(unittest.TestCase):
                   "--mirna", "../../data/examples/miraligner/miRNA.str",
                   "-o", "test_out_mirs_fasta",
                   "../../data/examples/miraligner/sim_isomir.fa"]
-            print " ".join(cl)
+            print(" ".join(cl))
             subprocess.check_call(cl)
 


### PR DESCRIPTION
Hello,
I think to have addressed a series of easy bits to prepare seqcluster for Python 3.

There are a few other bits, though. Could you please have a look at 
```
  File "/usr/lib/python3/dist-packages/seqcluster/detect/description.py", line 18
    data_loci = map(lambda (x): [x, loci[x].chr, int(loci[x].start), int(loci[x].end), loci[x].strand, len(c.loci2seq[x])], c.loci2seq.keys())
                           ^
SyntaxError: invalid syntax

  File "/usr/lib/python3/dist-packages/seqcluster/libs/annotation.py", line 28
    except Exception, e:
                    ^
SyntaxError: invalid syntax

  File "/usr/lib/python3/dist-packages/seqcluster/make_clusters.py", line 176
    data_ann_temp[dbi] = {dbi: map(lambda (x): loci[lid].db_ann[dbi].ann[x].name, loci[lid].db_ann[dbi].ann.keys())}
                                          ^
SyntaxError: invalid syntax

  File "/usr/lib/python3/dist-packages/seqcluster/stats.py", line 42
    seqs_name = map(lambda (x): x.keys(), item['seqs'])
                           ^
SyntaxError: invalid syntax
```
Can these bits possibly be addressed in a backward-compatible way? Can the 2to3 tool be a stimulus for you, possibly?

Many thanks and regards,

Steffen
