### PR TITLE
Python 3 support: use general fixes and six for 2 and 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
 - bash Miniconda-latest-Linux-x86_64.sh -b -p ~/install
 - export PATH=~/install/bin/:$PATH
-- conda install --yes -c conda-forge -c bioconda openjdk pyyaml pysam scipy pandas pybedtools progressbar bedtools samtools pip biopython nose scipy setuptools -q
+- conda install --yes -c conda-forge -c bioconda openjdk pyyaml pysam scipy pandas pybedtools progressbar2 bedtools samtools pip biopython nose scipy setuptools six -q
 - pip install mirtop
 - pip install pytz
 - pip install dateutils

--- a/reqs.txt
+++ b/reqs.txt
@@ -3,7 +3,8 @@ pybedtools>=0.6.8
 scipy>=0.15.1
 numpy
 nose>=1.3.0
-progressbar>=2.3.0
+progressbar2
 pandas>=0.14.1
 colorlog
 mirtop
+six

--- a/seqcluster/collapse.py
+++ b/seqcluster/collapse.py
@@ -19,7 +19,7 @@ def collapse_fastq(args):
         out_file = splitext_plus(os.path.basename(args.fastq))[0] + "_trimmed.fastq"
     except IOError as e:
         logger.error("I/O error({0}): {1}".format(e.errno, e.strerror))
-        raise "Can not read file"
+        raise IOError("Can not read file")
     out_file = os.path.join(args.out, out_file)
     write_output(out_file, seqs, args.minimum)
     return out_file

--- a/seqcluster/create_cluster_info.py
+++ b/seqcluster/create_cluster_info.py
@@ -27,7 +27,7 @@ for line in f:
                 out.close()
                 outfa.close()
                 isin = 0
-            if clus.has_key(line):
+            if line in clus:
                 out = open(options.out+"/"+line, 'w')
                 outfa = open(options.out+"/"+line+".fa", 'w')
                 out.write(line+"\n")

--- a/seqcluster/db/__init__.py
+++ b/seqcluster/db/__init__.py
@@ -30,17 +30,17 @@ def _get_description(string):
     return "annotated as: %s ..." % ",".join(list(ann)[:3])
 
 def _get_sequences(cluster):
-    seqs = [s.values()[0] for s in cluster['seqs']]
-    freqs = [f.values()[0] for f in cluster['freq']]
+    seqs = [list(s.values())[0] for s in cluster['seqs']]
+    freqs = [list(f.values())[0] for f in cluster['freq']]
     data = []
     total_freq = {}
     for s, f in zip(seqs, freqs):
-        fix = dict(zip(f.keys(), map(int, f.values())))
+        fix = dict(list(zip(list(f.keys()), list(map(int, list(f.values()))))))
         data.append({'name': s, 'freq': fix})
-        total_freq[s] = 1.0 * sum(fix.values()) / len(fix.values())
+        total_freq[s] = 1.0 * sum(fix.values()) / len(list(fix.values()))
     if len(total_freq) > 100:
         counts_50 = sorted(total_freq.values())[-100]
-        data = [e for e in data if 1.0 * sum(e['freq'].values()) / len(e['freq'].values()) > counts_50]
+        data = [e for e in data if 1.0 * sum(e['freq'].values()) / len(list(e['freq'].values())) > counts_50]
     return data
 
 def _take_closest(num,collection):
@@ -50,7 +50,7 @@ def _get_closer(dat, pos):
     if pos in dat:
         return pos
     else:
-        closest_pos = _take_closest(pos, dat.keys())
+        closest_pos = _take_closest(pos, list(dat.keys()))
         if abs(closest_pos - pos) < 3:
             return closest_pos
 
@@ -64,7 +64,7 @@ def _set_format(profile):
     if not x:
         return ''
     end, start = max(x), min(x)
-    x = range(start, end, 4)
+    x = list(range(start, end, 4))
     scaled_profile = defaultdict(list)
     for pos in x:
         for sample in profile:
@@ -73,7 +73,7 @@ def _set_format(profile):
                 scaled_profile[sample].append(profile[sample][y])
             else:
                 scaled_profile[sample].append(0)
-    return {'x': list(x), 'y': scaled_profile, 'names': scaled_profile.keys()}
+    return {'x': list(x), 'y': scaled_profile, 'names': list(scaled_profile.keys())}
 
 def _insert_data(con, data):
     """
@@ -88,7 +88,7 @@ def _insert_data(con, data):
             annotation = json.dumps(data[0][c]['ann'])
             description = _get_description(data[0][c]['ann'])
             sequences = json.dumps(_get_sequences(data[0][c]))
-            keys = data[0][c]['freq'][0].values()[0].keys()
+            keys = list(data[0][c]['freq'][0].values())[0].keys()
             profile = "Not available."
             if 'profile' in data[0][c]:
                 profile = json.dumps(_set_format(data[0][c]['profile']))

--- a/seqcluster/detect/description.py
+++ b/seqcluster/detect/description.py
@@ -61,7 +61,7 @@ def peak_calling(clus_obj):
             for pos in clus_obj.loci[bigger].counts:
                 ss = int(pos) - scale + 5
                 dt[ss] += clus_obj.loci[bigger].counts[pos]
-        x = np.array(range(0, len(dt)))
+        x = np.array(list(range(0, len(dt))))
         logger.debug("x %s and y %s" % (x, dt))
         # tab = pd.DataFrame({'x': x, 'y': dt})
         # tab.to_csv( str(cid) + "peaks.csv", mode='w', header=False, index=False)

--- a/seqcluster/function/peakdetect.py
+++ b/seqcluster/function/peakdetect.py
@@ -20,7 +20,7 @@ def find_mature(x, y, win=10):
     """
     previous = min(y)
     peaks = []
-    intervals = range(x, y, win)
+    intervals = list(range(x, y, win))
     for pos in intervals:
         if y[pos] > previous * 10:
             previous = y[pos]

--- a/seqcluster/function/rnafold.py
+++ b/seqcluster/function/rnafold.py
@@ -11,7 +11,7 @@ def run_rnafold(seqs):
     cmd = ("echo {seqs} | RNAfold").format(**locals())
     if len(seqs) < 150:
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-        for line in iter(process.stdout.readline, ''):
+        for line in str(process.stdout.read()).split(r"\n"):
             if line.find(" ") > -1:
                 out = "".join(line.split(" ")[1:]).strip()[1:-1].replace(" ", "")
                 structure = line.split(" ")[0]

--- a/seqcluster/function/target.py
+++ b/seqcluster/function/target.py
@@ -27,7 +27,7 @@ def targets_enrichment(args):
                 if mit in mirna_id_dict:
                     mirbase_id = mirna_id_dict[mit]
                     if mirbase_id in mirna_list:
-                        info = map(str, [cols[0], cols[1], cols[4], cols[-3], cols[-1]])
+                        info = list(map(str, [cols[0], cols[1], cols[4], cols[-3], cols[-1]]))
                         keep = "\t".join(info)
                         if cols[-3] == "NULL":
                             cols[-3] = 0

--- a/seqcluster/libs/barchart.py
+++ b/seqcluster/libs/barchart.py
@@ -101,7 +101,7 @@ def createdata(info):
 		infodb=db
 		#print "%s %s \n" % (infodb["DB"],infodb["uni"])
 		jsdb="{"
-		for k in infodb.keys():
+		for k in list(infodb.keys()):
 			jsdb+='"%s":"%s",' % (k,infodb[k])
 		#jsdb='{"args":%s, "uni":%s , "mul":%s, "nocon":%s\n},' % (infodb["DB"],infodb["uni"],infodb["mul"],infodb["nocon"])
 		chartData+=jsdb[:-1]+"},"

--- a/seqcluster/libs/bayes.py
+++ b/seqcluster/libs/bayes.py
@@ -54,13 +54,13 @@ def _dict_seq_locus(list_c, loci_obj, seq_obj):
     """
     seqs = defaultdict(set)
     # n = len(list_c.keys())
-    for c in list_c.values():
+    for c in list(list_c.values()):
         for l in c.loci2seq:
             [seqs[s].add(c.id) for s in c.loci2seq[l]]
 
     common = [s for s in seqs if len(seqs[s]) > 1]
     seqs_in_c = defaultdict(float)
-    for c in list_c.values():
+    for c in list(list_c.values()):
         for l in c.loci2seq:
             # total = sum([v for v in loci_obj[l].coverage.values()])
             for s in c.loci2seq[l]:
@@ -76,7 +76,7 @@ def _dict_seq_locus(list_c, loci_obj, seq_obj):
 
 def _bayes(loci):
     data = defaultdict(dict)
-    hypos = loci.keys()
+    hypos = list(loci.keys())
     for hypo in hypos:
         data[hypo] = dict(position=loci[hypo])
     pmf = _update(hypos, data)
@@ -90,8 +90,8 @@ def decide_by_bayes(list_c, s2p):
     seqs_in_c = _dict_seq_locus(list_c, loci_obj, seq_obj)
     for s in seqs_in_c:
         total = sum(seqs_in_c[s].values())
-        norm_values = 1.0 * np.array(seqs_in_c[s].values()) / total
-        prob = _bayes(dict(zip(seqs_in_c[s].keys(), norm_values)))
+        norm_values = 1.0 * np.array(list(seqs_in_c[s].values())) / total
+        prob = _bayes(dict(list(zip(list(seqs_in_c[s].keys()), norm_values))))
         for clus in prob:
             list_c[clus].idmembers[s] = prob.loci[clus]["position"]
             # print "%s %s %s" % (s, clus, list_c[clus].idmembers[s])

--- a/seqcluster/libs/classes.py
+++ b/seqcluster/libs/classes.py
@@ -58,12 +58,12 @@ class quality:
 
     def update(self, q, counts = 1):
         now = self.qual
-        self.qual = map(add, now, [ord(value) for value in q])
+        self.qual = list(map(add, now, [ord(value) for value in q]))
         self.times += counts
 
     def get(self):
-        average = map(lambda x: int(round(x/self.times)), self.qual)
-        return [str(unichr(char)) for char in average]
+        average = [int(round(x/self.times)) for x in self.qual]
+        return [str(chr(char)) for char in average]
 
 
 class cluster_info_obj:
@@ -123,7 +123,7 @@ class position:
         self.db_ann = {}
 
     def list(self):
-        return map(str, [self.chr, self. start, self.end, self.idl, self.strand])
+        return list(map(str, [self.chr, self. start, self.end, self.idl, self.strand]))
 
     def add_db(self, db, ndb):
         self.db_ann[db] = ndb
@@ -175,11 +175,11 @@ class cluster:
         self.freq = []
 
     def normalize(self, seq, factor):
-        return dict(zip(seq.freq.keys(), list(np.array(seq.freq.values()) * factor)))
+        return dict(list(zip(list(seq.freq.keys()), list(np.array(list(seq.freq.values())) * factor))))
 
     def set_freq(self, seqL):
         total = Counter()
-        [total.update(self.normalize(seqL[s], f)) for s, f in self.idmembers.iteritems()]
+        [total.update(self.normalize(seqL[s], f)) for s, f in self.idmembers.items()]
         self.freq = total
         return total
 
@@ -208,8 +208,8 @@ class cluster:
                 self.locimaxid = idl
         remove = set(self.idmembers.keys()) - seen
         add = seen - set(self.idmembers.keys())
-        self.idmembers.update(dict(zip(add, [1] * len(add))))
-        map(self.idmembers.__delitem__, remove)
+        self.idmembers.update(dict(list(zip(add, [1] * len(add)))))
+        list(map(self.idmembers.__delitem__, remove))
 
     def add_id_member(self, ids, idl):
         for s in ids:
@@ -220,7 +220,7 @@ class cluster:
         self.loci2seq[idl] = list(set(self.loci2seq[idl]))
         lenid = len(self.loci2seq[idl])
         self.locilen[idl] = lenid
-        if lenid > self.locimax:
+        if self.locimax is None or lenid > self.locimax:
             self.locimax = lenid
             self.locimaxid = idl
 

--- a/seqcluster/libs/do.py
+++ b/seqcluster/libs/do.py
@@ -5,6 +5,9 @@ import os
 import subprocess
 import logging
 
+import six
+
+
 logger = logging.getLogger("run")
 
 
@@ -13,7 +16,7 @@ def run(cmd, data=None, checks=None, region=None, log_error=True,
     """Run the provided command, logging details and checking for errors.
     """
     try:
-        logger.debug(" ".join(str(x) for x in cmd) if not isinstance(cmd, basestring) else cmd)
+        logger.debug(" ".join(str(x) for x in cmd) if not isinstance(cmd, six.string_types) else cmd)
         _do_run(cmd, checks, log_stdout)
     except:
         if log_error:
@@ -37,7 +40,7 @@ def _normalize_cmd_args(cmd):
     Piped commands set pipefail and require use of bash to help with debugging
     intermediate errors.
     """
-    if isinstance(cmd, basestring):
+    if isinstance(cmd, six.string_types):
         # check for standard or anonymous named pipes
         if cmd.find(" | ") > 0 or cmd.find(">(") or cmd.find("<("):
             return "set -o pipefail; " + cmd, True, find_bash()
@@ -67,7 +70,7 @@ def _do_run(cmd, checks, log_stdout=False):
             for line in s.stdout:
                 debug_stdout.append(line)
             if exitcode is not None and exitcode != 0:
-                error_msg = " ".join(cmd) if not isinstance(cmd, basestring) else cmd
+                error_msg = " ".join(cmd) if not isinstance(cmd, six.string_types) else cmd
                 error_msg += "\n"
                 error_msg += "".join(debug_stdout)
                 s.communicate()

--- a/seqcluster/libs/parse.py
+++ b/seqcluster/libs/parse.py
@@ -21,7 +21,7 @@ def parse_cl(in_args):
         sub_cmds[in_args[0]](subparsers)
         sub_cmd = in_args[0]
     else:
-        print("use %s" % sub_cmds.keys())
+        print("use %s" % list(sub_cmds.keys()))
         sys.exit(0)
     args = parser.parse_args()
 

--- a/seqcluster/libs/read.py
+++ b/seqcluster/libs/read.py
@@ -109,7 +109,7 @@ def map_to_precursor_biopython(seqs, names, loci, args):
     """map the sequences using biopython package"""
     precursor = precursor_sequence(loci, args.ref).upper()
     dat = dict()
-    for s, n in itertools.izip(seqs, names):
+    for s, n in zip(seqs, names):
         res = _align(str(s), precursor)
         if res:
             dat[n] = res
@@ -153,7 +153,7 @@ def get_loci_fasta(loci, out_fa, ref):
         raise ValueError("Not bedtools installed")
     with make_temp_directory() as temp:
         bed_file = os.path.join(temp, "file.bed")
-        for nc, loci in loci.iteritems():
+        for nc, loci in loci.items():
             for l in loci:
                 with open(bed_file, 'w') as bed_handle:
                     logger.debug("get_fasta: loci %s" % l)
@@ -176,7 +176,7 @@ def read_alignment(out_sam, loci, seqs, out_file):
                     continue
                 ref, locus = get_loci(samfile.getrname(int(a.chr)), loci)
                 hits[a.name].append((nm, "%s %s %s %s %s %s" % (a.name, a.name.split("-")[0], locus, ref, a.start, a.end)))
-        for hit in hits.values():
+        for hit in list(hits.values()):
             nm = hit[0][0]
             for l in hit:
                 if nm == l[0]:

--- a/seqcluster/libs/report.py
+++ b/seqcluster/libs/report.py
@@ -33,7 +33,7 @@ def _parse(profile, size):
     for sample in profile:
         for pos in range(len(size)):
             total[pos] += profile[sample][pos]
-    return total.values()
+    return list(total.values())
 
 
 def make_profile(data, out_dir, args):
@@ -44,19 +44,18 @@ def make_profile(data, out_dir, args):
     main_table = []
     header = ['id', 'ann']
     n = len(data[0])
-    bar = ProgressBar(maxval=n)
-    bar.start()
-    bar.update(0)
-    for itern, c in enumerate(data[0]):
-        bar.update(itern)
-        logger.debug("creating cluser: {}".format(c))
-        safe_dirs(os.path.join(out_dir, c))
-        valid, ann, pos_structure = _single_cluster(c, data, os.path.join(out_dir, c, "maps.tsv"), args)
-        data[0][c].update({'profile': pos_structure})
-        loci = data[0][c]['loci']
-        data[0][c]['precursor'] = {"seq": precursor_sequence(loci[0][0:5], args.ref)}
-        data[0][c]['precursor']["colors"] = _parse(data[0][c]['profile'], data[0][c]['precursor']["seq"])
-        data[0][c]['precursor'].update(run_rnafold(data[0][c]['precursor']['seq']))
+    with ProgressBar(maxval=n) as bar:
+        bar.update(0)
+        for itern, c in enumerate(data[0]):
+            bar.update(itern)
+            logger.debug("creating cluser: {}".format(c))
+            safe_dirs(os.path.join(out_dir, c))
+            valid, ann, pos_structure = _single_cluster(c, data, os.path.join(out_dir, c, "maps.tsv"), args)
+            data[0][c].update({'profile': pos_structure})
+            loci = data[0][c]['loci']
+            data[0][c]['precursor'] = {"seq": precursor_sequence(loci[0][0:5], args.ref)}
+            data[0][c]['precursor']["colors"] = _parse(data[0][c]['profile'], data[0][c]['precursor']["seq"])
+            data[0][c]['precursor'].update(run_rnafold(data[0][c]['precursor']['seq']))
 
     return data
 
@@ -76,7 +75,7 @@ def _convert_to_df(in_file, freq, raw_file):
     convert data frame into table with pandas
     """
     dat = defaultdict(Counter)
-    if isinstance(in_file, (str, unicode)):
+    if isinstance(in_file, str):
         with open(in_file) as in_handle:
             for line in in_handle:
                 cols = line.strip().split("\t")
@@ -123,9 +122,9 @@ def _single_cluster(c, data, out_file, args):
     valid, ann = 0, 0
     raw_file = None
     freq = defaultdict()
-    [freq.update({s.keys()[0]: s.values()[0]}) for s in data[0][c]['freq']]
-    names = [s.keys()[0] for s in data[0][c]['seqs']]
-    seqs = [s.values()[0] for s in data[0][c]['seqs']]
+    [freq.update({list(s.keys())[0]: list(s.values())[0]}) for s in data[0][c]['freq']]
+    names = [list(s.keys())[0] for s in data[0][c]['seqs']]
+    seqs = [list(s.values())[0] for s in data[0][c]['seqs']]
     loci = data[0][c]['loci']
 
     if loci[0][3] - loci[0][2] > 500:

--- a/seqcluster/libs/thinkbayes.py
+++ b/seqcluster/libs/thinkbayes.py
@@ -164,7 +164,7 @@ class _DictWrapper(object):
 
         values: map from value to probability
         """
-        for value, prob in values.iteritems():
+        for value, prob in values.items():
             self.Set(value, prob)
 
     def InitPmf(self, values):
@@ -233,7 +233,7 @@ class _DictWrapper(object):
         if m is None:
             m = self.MaxLike()
 
-        for x, p in self.d.iteritems():
+        for x, p in self.d.items():
             if p:
                 self.Set(x, math.log(p / m))
             else:
@@ -253,7 +253,7 @@ class _DictWrapper(object):
         if m is None:
             m = self.MaxLike()
 
-        for x, p in self.d.iteritems():
+        for x, p in self.d.items():
             self.Set(x, math.exp(p - m))
 
     def GetDict(self):
@@ -271,11 +271,11 @@ class _DictWrapper(object):
         dictionary are the values of the Hist/Pmf, and the
         values of the dictionary are frequencies/probabilities.
         """
-        return self.d.keys()
+        return list(self.d.keys())
 
     def Items(self):
         """Gets an unsorted sequence of (value, freq/prob) pairs."""
-        return self.d.items()
+        return list(self.d.items())
 
     def Render(self):
         """Generates a sequence of points suitable for plotting.
@@ -283,11 +283,11 @@ class _DictWrapper(object):
         Returns:
             tuple of (sorted value sequence, freq/prob sequence)
         """
-        return zip(*sorted(self.Items()))
+        return list(zip(*sorted(self.Items())))
 
     def Print(self):
         """Prints the values and freqs/probs in ascending order."""
-        for val, prob in sorted(self.d.iteritems()):
+        for val, prob in sorted(self.d.items()):
             print(val, prob)
 
     def Set(self, x, y=0):
@@ -329,12 +329,12 @@ class _DictWrapper(object):
 
     def Total(self):
         """Returns the total of the frequencies/probabilities in the map."""
-        total = sum(self.d.itervalues())
+        total = sum(self.d.values())
         return total
 
     def MaxLike(self):
         """Returns the largest frequency/probability in the map."""
-        return max(self.d.itervalues())
+        return max(self.d.values())
 
 
 class Hist(_DictWrapper):
@@ -406,7 +406,7 @@ class Pmf(_DictWrapper):
 
         returns: float probability
         """
-        t = [prob for (val, prob) in self.d.iteritems() if val > x]
+        t = [prob for (val, prob) in self.d.items() if val > x]
         return sum(t)
 
     def ProbLess(self, x):
@@ -416,7 +416,7 @@ class Pmf(_DictWrapper):
 
         returns: float probability
         """
-        t = [prob for (val, prob) in self.d.iteritems() if val < x]
+        t = [prob for (val, prob) in self.d.items() if val < x]
         return sum(t)
 
     def __lt__(self, obj):
@@ -516,7 +516,7 @@ class Pmf(_DictWrapper):
 
         target = random.random()
         total = 0.0
-        for x, p in self.d.iteritems():
+        for x, p in self.d.items():
             total += p
             if total >= target:
                 return x
@@ -531,7 +531,7 @@ class Pmf(_DictWrapper):
             float mean
         """
         mu = 0.0
-        for x, p in self.d.iteritems():
+        for x, p in self.d.items():
             mu += p * x
         return mu
 
@@ -549,7 +549,7 @@ class Pmf(_DictWrapper):
             mu = self.Mean()
 
         var = 0.0
-        for x, p in self.d.iteritems():
+        for x, p in self.d.items():
             var += p * (x - mu) ** 2
         return var
 
@@ -902,7 +902,7 @@ class Cdf(object):
 
         Note: in Python3, returns an iterator.
         """
-        return zip(self.xs, self.ps)
+        return list(zip(self.xs, self.ps))
 
     def Append(self, x, p):
         """Add an (x, p) pair to the end of this CDF.
@@ -1098,7 +1098,7 @@ def MakeCdfFromDict(d, name=''):
     Returns:
         Cdf object
     """
-    return MakeCdfFromItems(d.iteritems(), name)
+    return MakeCdfFromItems(iter(d.items()), name)
 
 
 def MakeCdfFromHist(hist, name=''):
@@ -1382,7 +1382,7 @@ class EstimatedPdf(Pdf):
 
     def MakePmf(self, xs, name=''):
         ps = self.kde.evaluate(xs)
-        pmf = MakePmfFromItems(zip(xs, ps), name=name)
+        pmf = MakePmfFromItems(list(zip(xs, ps)), name=name)
         return pmf
 
 
@@ -1490,7 +1490,7 @@ def SampleSum(dists, n):
 
     returns: new Pmf of sums
     """
-    pmf = MakePmfFromList(RandomSum(dists) for i in xrange(n))
+    pmf = MakePmfFromList(RandomSum(dists) for i in range(n))
     return pmf
 
 
@@ -1559,7 +1559,7 @@ def MakePoissonPmf(lam, high, step=1):
     returns: normalized Pmf
     """
     pmf = Pmf()
-    for k in xrange(0, high + 1, step):
+    for k in range(0, high + 1, step):
         p = EvalPoissonPmf(k, lam)
         pmf.Set(k, p)
     pmf.Normalize()
@@ -1706,14 +1706,14 @@ class Beta(object):
             pmf = cdf.MakePmf()
             return pmf
 
-        xs = [i / (steps - 1.0) for i in xrange(steps)]
+        xs = [i / (steps - 1.0) for i in range(steps)]
         probs = [self.EvalPdf(x) for x in xs]
-        pmf = MakePmfFromDict(dict(zip(xs, probs)), name)
+        pmf = MakePmfFromDict(dict(list(zip(xs, probs))), name)
         return pmf
 
     def MakeCdf(self, steps=101):
         """Returns the CDF of this distribution."""
-        xs = [i / (steps - 1.0) for i in xrange(steps)]
+        xs = [i / (steps - 1.0) for i in range(steps)]
         ps = [scipy.special.betainc(self.alpha, self.beta, x) for x in xs]
         cdf = Cdf(xs, ps)
         return cdf
@@ -1810,7 +1810,7 @@ class Dirichlet(object):
         """
         alpha0 = self.params.sum()
         ps = self.params / alpha0
-        return MakePmfFromItems(zip(xs, ps), name=name)
+        return MakePmfFromItems(list(zip(xs, ps)), name=name)
 
 
 def BinomialCoef(n, k):

--- a/seqcluster/libs/tool.py
+++ b/seqcluster/libs/tool.py
@@ -46,8 +46,8 @@ def calculate_size(vector):
     maxfreq = 0
     zeros = 0
     counts = 0
-    total = len(vector.keys())
-    for s in vector.keys():
+    total = len(list(vector.keys()))
+    for s in list(vector.keys()):
         maxfreq = max(vector[s], maxfreq)
         counts += int(vector[s])
         if vector[s] == 0:
@@ -63,12 +63,12 @@ def show_seq(clus_obj, index):
     clus_locit = clus_obj.loci
 
     itern = 0
-    for idc in current.keys():
+    for idc in list(current.keys()):
         itern += 1
         timestamp = str(idc)
         seqListTemp = ()
         f = open("/tmp/"+timestamp+".fa","w")
-        for idl in current[idc].loci2seq.keys():
+        for idl in list(current[idc].loci2seq.keys()):
             seqListTemp = list(set(seqListTemp).union(current[idc].loci2seq[idl]))
         maxscore = 0
         for s in seqListTemp:
@@ -79,7 +79,7 @@ def show_seq(clus_obj, index):
             f.write(">"+s+"\n"+seq.seq+"\n")
         f.close()
 
-        locilen_sorted = sorted(current[idc].locilen.iteritems(), key = operator.itemgetter(1),reverse = True)
+        locilen_sorted = sorted(iter(current[idc].locilen.items()), key = operator.itemgetter(1),reverse = True)
         lmax = clus_locit[locilen_sorted[0][0]]
         f = open("/tmp/"+timestamp+".bed","w")
         f.write("%s\t%s\t%s\t.\t.\t%s\n" % (lmax.chr,lmax.start,lmax.end,lmax.strand))
@@ -97,7 +97,7 @@ def show_seq(clus_obj, index):
             if minv>int(cols[3]):
                 minv = int(cols[3])
         f.close()
-        seqpos_sorted = sorted(seqpos.iteritems(), key = operator.itemgetter(1),reverse = False)
+        seqpos_sorted = sorted(iter(seqpos.items()), key = operator.itemgetter(1),reverse = False)
         showseq = ""
         showseq_plain = ""
         for (s,pos) in seqpos_sorted:
@@ -121,9 +121,9 @@ def generate_position_bed(clus_obj):
     ##generate file with positions in bed format
     bedaligned = ""
     clus_id = clus_obj.clus
-    for idc in clus_id.keys():
+    for idc in list(clus_id.keys()):
         clus = clus_id[idc]
-        for idl in clus.loci2seq.keys():
+        for idl in list(clus.loci2seq.keys()):
             pos = clus_obj.loci[idl]
             bedaligned +=  "%s\t%s\t%s\t%s\t%s\t%s\n" % (pos.chr,pos.start,pos.end,idc,idl,pos.strand)
     return bedaligned

--- a/seqcluster/make_clusters.py
+++ b/seqcluster/make_clusters.py
@@ -48,27 +48,27 @@ def cluster(args):
     # y, l = _total_counts(seqL.keys(), seqL)
     logger.info("counts after: %s" % sum(y.values()))
     logger.info("# sequences after: %s" % l)
-    dt = pd.DataFrame({'sample': y.keys(), 'counts': y.values()})
+    dt = pd.DataFrame({'sample': list(y.keys()), 'counts': list(y.values())})
     dt['step'] = 'aligned'
     dt.to_csv(read_stats_file, sep="\t", index=False, header=False, mode='a')
 
-    if len(seqL.keys()) < 10:
+    if len(list(seqL.keys())) < 10:
         logger.error("It seems you have low coverage. Please check your fastq files have enough sequences.")
         raise ValueError("So few sequences.")
 
     logger.info("Cleaning bam file")
-    y, l = _total_counts(seqL.keys(), seqL)
+    y, l = _total_counts(list(seqL.keys()), seqL)
     logger.info("counts after: %s" % sum(y.values()))
     logger.info("# sequences after: %s" % l)
-    dt = pd.DataFrame({'sample': y.keys(), 'counts': y.values()})
+    dt = pd.DataFrame({'sample': list(y.keys()), 'counts': list(y.values())})
     dt['step'] = 'cleaned'
     dt.to_csv(read_stats_file, sep="\t", index=False, header=False, mode='a')
 
     clusL = _create_clusters(seqL, bam_file, args)
-    y, l = _total_counts(clusL.seq.keys(), clusL.seq, aligned=True)
+    y, l = _total_counts(list(clusL.seq.keys()), clusL.seq, aligned=True)
     logger.info("counts after: %s" % sum(y.values()))
     logger.info("# sequences after: %s" % l)
-    dt = pd.DataFrame({'sample': y.keys(), 'counts': y.values()})
+    dt = pd.DataFrame({'sample': list(y.keys()), 'counts': list(y.values())})
     dt['step'] = 'clusters'
     dt.to_csv(read_stats_file, sep="\t", index=False, header=False, mode='a')
 
@@ -77,10 +77,10 @@ def cluster(args):
     y, l = _total_counts(clusLred.clus, seqL)
     logger.info("counts after: %s" % sum(y.values()))
     logger.info("# sequences after: %s" % l)
-    dt = pd.DataFrame({'sample': y.keys(), 'counts': y.values()})
+    dt = pd.DataFrame({'sample': list(y.keys()), 'counts': list(y.values())})
     dt['step'] = 'meta-cluster'
     dt.to_csv(read_stats_file, sep="\t", index=False, header=False, mode='a')
-    logger.info("Clusters up to %s" % (len(clusLred.clus.keys())))
+    logger.info("Clusters up to %s" % (len(list(clusLred.clus.keys()))))
 
     if args.show:
         logger.info("Creating sequences alignment to precursor")
@@ -164,7 +164,7 @@ def _total_counts(seqs, seqL, aligned=False):
 def _write_size_table(data_freq, data_len, ann_valid, cluster_id):
     dd = Counter()
     for f, l in zip(data_freq, data_len):
-        dd[l] += np.mean(f.values())
+        dd[l] += np.mean(list(f.values()))
 
     table = ""
     for l in sorted(dd):
@@ -190,9 +190,9 @@ def _get_annotation(c, loci):
         # suggestion by 2to3
         data_ann = data_ann + [data_ann_temp[x] for x in list(data_ann_temp.keys())]
         logger.debug("_json_: data_ann %s" % data_ann)
-    counts = {k: v for k, v in counts.iteritems()}
+    counts = {k: v for k, v in counts.items()}
     total_loci = sum([counts[db] for db in counts])
-    valid_ann = [k for k, v in counts.iteritems() if up_threshold(v, total_loci, 0.7)]
+    valid_ann = [k for k, v in counts.items() if up_threshold(v, total_loci, 0.7)]
     return data_ann, valid_ann
 
 
@@ -202,10 +202,10 @@ def _get_counts(list_seqs, seqs_obj, factor):
     for s in list_seqs:
         if s not in factor:
             factor[s] = 1
-        samples = seqs_obj[s].norm_freq.keys()
-        corrected_norm = np.array(seqs_obj[s].norm_freq.values()) * factor[s]
-        corrected_raw = np.array(seqs_obj[s].freq.values()) * factor[s]
-        scaled[s] = seq(dict(zip(samples, corrected_raw)), dict(zip(samples, corrected_norm)))
+        samples = list(seqs_obj[s].norm_freq.keys())
+        corrected_norm = np.array(list(seqs_obj[s].norm_freq.values())) * factor[s]
+        corrected_raw = np.array(list(seqs_obj[s].freq.values())) * factor[s]
+        scaled[s] = seq(dict(list(zip(samples, corrected_raw))), dict(list(zip(samples, corrected_norm))))
     return scaled
 
 
@@ -213,7 +213,7 @@ def _sum_by_samples(seqs_freq, samples_order):
     """
     Sum sequences of a metacluster by samples.
     """
-    n = len(seqs_freq[seqs_freq.keys()[0]].freq.keys())
+    n = len(list(seqs_freq[list(seqs_freq.keys())[0]].freq.keys()))
     y = np.array([0] * n)
     for s in seqs_freq:
         x = seqs_freq[s].freq
@@ -310,7 +310,7 @@ def _create_json(clusL, args):
     out_single_count = os.path.join(args.dir_out, "counts_sequence.tsv")
     out_size = os.path.join(args.dir_out, "size_counts.tsv")
     out_bed = os.path.join(args.dir_out, "positions.bed")
-    samples_order = list(seqs[seqs.keys()[1]].freq.keys())
+    samples_order = list(seqs[list(seqs.keys())[1]].freq.keys())
     with open(out_count, 'w') as matrix, open(out_size, 'w') as size_matrix, open(out_bed, 'w') as out_bed, open(out_single_count, 'w') as matrix_single:
         matrix.write("id\tnloci\tann\t%s\n" % "\t".join(samples_order))
         matrix_single.write("id\tnloci\tann\t%s\n" % "\t".join(samples_order))
@@ -343,14 +343,14 @@ def _create_json(clusL, args):
 
             sum_freq = _sum_by_samples(scaled_seqs, samples_order)
 
-            data_ann_str = [["%s::%s" % (name, ",".join(features)) for name, features in k.iteritems()] for k in data_ann]
+            data_ann_str = [["%s::%s" % (name, ",".join(features)) for name, features in k.items()] for k in data_ann]
             data_valid_str = " ".join(valid_ann)
 
             for s in seqList:
                 f = [seqs[s].freq[so] for so in samples_order]
                 if f.count(0) > 0.1 * len(f) and len(f) > 9:
                     continue
-                f = map(str, f)
+                f = list(map(str, f))
                 print("\t".join([str(cid), data_valid_str, seqs[s].seq, "\t".join(f)]), file=matrix_single, end="")
 
             matrix.write("%s\t%s\t%s|%s\t%s\n" % (cid, c.toomany, data_valid_str, ";".join([";".join(d) for d in data_ann_str]), "\t".join(map(str, sum_freq))))
@@ -362,6 +362,15 @@ def _create_json(clusL, args):
 
     out_file = os.path.join(args.dir_out, "seqcluster.json")
     with open(out_file, 'w') as handle_out:
-        handle_out.write(json.dumps([data_clus], skipkeys=True, indent=2))
-
+        class NumpyEncoder(json.JSONEncoder):
+            """Avoid numpy objects in output serialization.
+            Thanks to: https://stackoverflow.com/questions/26646362/numpy-array-is-not-json-serializable
+            """
+            def default(self, obj):
+                if isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                if isinstance(obj, np.int64):
+                    return int(obj)
+                return json.JSONEncoder.default(self, obj)
+        handle_out.write(json.dumps([data_clus], skipkeys=True, indent=2, cls=NumpyEncoder))
     return out_file

--- a/seqcluster/methods/__init__.py
+++ b/seqcluster/methods/__init__.py
@@ -8,8 +8,8 @@ def read_cluster(data, id=1):
     cl = cluster(1)
 
     # seqs = [s.values()[0] for s in data['seqs']]
-    names = [s.keys()[0] for s in data['seqs']]
+    names = [list(s.keys())[0] for s in data['seqs']]
     cl.add_id_member(names, 1)
     freq = defaultdict()
-    [freq.update({s.keys()[0]: s.values()[0]}) for s in data['freq']]
+    [freq.update({list(s.keys())[0]: list(s.values())[0]}) for s in data['freq']]
 

--- a/seqcluster/prepare_data.py
+++ b/seqcluster/prepare_data.py
@@ -151,7 +151,7 @@ def _create_matrix_uniq_seq(sample_l, seq_l, maout, out, min_shared):
     maout.write("id\tseq")
     for g in sample_l:
         maout.write("\t%s" % g)
-    for s in seq_l.keys():
+    for s in list(seq_l.keys()):
         seen = sum([1 for g in seq_l[s].group if seq_l[s].group[g] > 0])
         if seen < int(min_shared):
             skip += 1

--- a/seqcluster/seqbuster/__init__.py
+++ b/seqcluster/seqbuster/__init__.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pysam
 import argparse
 
+import six
+
 from seqcluster.libs import do
 from seqcluster.libs.utils import file_exists
 import seqcluster.libs.logger as mylog
@@ -92,7 +94,7 @@ def _convert_to_fasta(fn):
 def _get_pos(string):
     name = string.split(":")[0][1:]
     pos = string.split(":")[1][:-1].split("-")
-    return name, map(int, pos)
+    return name, list(map(int, pos))
 
 
 def _read_mature(matures, sps):
@@ -341,7 +343,7 @@ def _read_miraligner(fn):
     """Read ouput of miraligner and create compatible output."""
     reads = defaultdict(realign)
     with open(fn) as in_handle:
-        in_handle.next()
+        six.next(in_handle)
         for line in in_handle:
             cols = line.strip().split("\t")
             iso = isomir()
@@ -408,11 +410,11 @@ def _tab_output(reads, out_file, sample):
     dt = None
     with open(out_file, 'w') as out_handle:
         print("name\tseq\tfreq\tchrom\tstart\tend\tsubs\tadd\tt5\tt3\ts5\ts3\tDB\tprecursor\thits", file=out_handle, end="")
-        for r, read in reads.iteritems():
+        for r, read in reads.items():
             hits = set()
-            [hits.add(mature.mirna) for mature in read.precursors.values() if mature.mirna]
+            [hits.add(mature.mirna) for mature in list(read.precursors.values()) if mature.mirna]
             hits = len(hits)
-            for p, iso in read.precursors.iteritems():
+            for p, iso in read.precursors.items():
                 if len(iso.subs) > 3 or not iso.mirna:
                     continue
                 if (r, iso.mirna) not in seen:
@@ -525,11 +527,11 @@ def miraligner(args):
                 vcf.Reader(filename=vcf_file)
             except Exception as e:
                 logger.warning(e.__doc__)
-                logger.warning(e.message)
+                logger.warning(str(e))
         except Exception as e:
             # traceback.print_exc()
             logger.warning(e.__doc__)
-            logger.warning(e.message)
+            logger.warning(str(e))
         if isinstance(dt, pd.DataFrame):
             out_dts.append(dt)
 

--- a/seqcluster/stats.py
+++ b/seqcluster/stats.py
@@ -55,7 +55,7 @@ def _summarise_sam(counts, is_align, is_json, is_db):
     summary_align = defaultdict(Counter)
     summary_json = defaultdict(Counter)
     summary_db = defaultdict(Counter)
-    for s, o in counts.iteritems():
+    for s, o in counts.items():
         l = len(o.seq)
         if s in is_align:
             summary_align[l].update(o.freq)
@@ -68,12 +68,12 @@ def _summarise_sam(counts, is_align, is_json, is_db):
 
 def _write_suma(d, fn):
     with open(fn, 'w') as handle:
-        for l, counts in d[0].iteritems():
-            for e, freq in counts.iteritems():
+        for l, counts in d[0].items():
+            for e, freq in counts.items():
                 handle.write("%s %s %s align\n" % (l, e, freq))
-        for l, counts in d[1].iteritems():
-            for e, freq in counts.iteritems():
+        for l, counts in d[1].items():
+            for e, freq in counts.items():
                 handle.write("%s %s %s json\n" % (l, e, freq))
-        for l, counts in d[2].iteritems():
-            for e, freq in counts.iteritems():
+        for l, counts in d[2].items():
+            for e, freq in counts.items():
                 handle.write("%s %s %s %s\n" % (l[0], e, freq, l[1]))


### PR DESCRIPTION
Builds on top of miRTop/mirtop#50 to add Python 3 support for
seqcluster, as a prelude to working on this in bcbio. This also uses six
and generic changes where applicable and tests currently pass on both 2
and 3.

- Moves from progressbar (no 3 support) to progressbar2, which
  dependency and code changes
- Add six as a dependency and use for generally specifying basestring/str.
- Use six.next for general iteration where needed.
- Add NumpyEncoder to handle issues with dumping to json since it can't
  serialize numpy arrays or int64s.
- Avoid string/byte error when reading stdout from RNAfold.
- Avoid changes in iterators/lists from 2/3 by enumerating with list.
- Small changes that trigger lint errors on 3 (avoiding bare raise statements)