### PR TITLE
Python 3 support: progressbar2 and list/iterator fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pybedtools>=0.6.8
 scipy>=0.15.1
 numpy
 nose>=1.3.0
-progressbar>=2.3.0
+progressbar2
 pandas>=0.14.1
 colorlog
 mirtop

--- a/seqcluster/create_cluster_info.py
+++ b/seqcluster/create_cluster_info.py
@@ -27,7 +27,7 @@ for line in f:
                 out.close()
                 outfa.close()
                 isin = 0
-            if clus.has_key(line):
+            if line in clus:
                 out = open(options.out+"/"+line, 'w')
                 outfa = open(options.out+"/"+line+".fa", 'w')
                 out.write(line+"\n")

--- a/seqcluster/detect/cluster.py
+++ b/seqcluster/detect/cluster.py
@@ -153,28 +153,27 @@ def _find_metaclusters(clus_obj, sequence2clusters, current_seq, min_seqs):
     c_index = len(sequence2clusters)
     logger.info("Creating meta-clusters based on shared sequences: %s" % c_index)
     meta_idx = 1
-    bar = ProgressBar(maxval=c_index)
-    bar.start()
-    bar.update()
-    for itern, name in enumerate(sequence2clusters):
-        clusters = sequence2clusters[name]
-        if len(clusters) == 0:
-            c_index -= 1
-            continue
-        current_seq[name].align = 1
-        meta_idx += 1
-        bar.update(itern)
-        already_in = _common(clusters, seen)
-        _update(clusters, meta_idx, seen)
-        metacluster[meta_idx] = metacluster[meta_idx].union(clusters)
+    with ProgressBar(maxval=c_index) as bar:
+        bar.update()
+        for itern, name in enumerate(sequence2clusters):
+            clusters = sequence2clusters[name]
+            if len(clusters) == 0:
+                c_index -= 1
+                continue
+            current_seq[name].align = 1
+            meta_idx += 1
+            bar.update(itern)
+            already_in = _common(clusters, seen)
+            _update(clusters, meta_idx, seen)
+            metacluster[meta_idx] = metacluster[meta_idx].union(clusters)
 
-        if already_in:
-            for seen_metacluster in already_in:
-                clusters2merge = metacluster[seen_metacluster]
-                metacluster[meta_idx] = metacluster[meta_idx].union(clusters2merge)
-                _update(clusters2merge, meta_idx, seen)
-                # metacluster[seen_metacluster] = 0
-                del metacluster[seen_metacluster]
+            if already_in:
+                for seen_metacluster in already_in:
+                    clusters2merge = metacluster[seen_metacluster]
+                    metacluster[meta_idx] = metacluster[meta_idx].union(clusters2merge)
+                    _update(clusters2merge, meta_idx, seen)
+                    # metacluster[seen_metacluster] = 0
+                    del metacluster[seen_metacluster]
     logger.info("%s metaclusters from %s sequences" % (len(metacluster), c_index))
 
     return metacluster, seen

--- a/seqcluster/detect/metacluster.py
+++ b/seqcluster/detect/metacluster.py
@@ -61,22 +61,21 @@ def reduceloci(clus_obj,  path):
     large = 0
     current = clus_obj.clusid
     logger.info("Number of loci: %s" % len(clus_obj.loci.keys()))
-    bar = ProgressBar(maxval=len(current))
-    bar.start()
-    bar.update(0)
-    for itern, idmc in enumerate(current):
-        bar.update(itern)
-        logger.debug("_reduceloci: cluster %s" % idmc)
-        c = copy.deepcopy(list(current[idmc]))
+    with ProgressBar(maxval=len(current)) as bar:
+        bar.update(0)
+        for itern, idmc in enumerate(current):
+            bar.update(itern)
+            logger.debug("_reduceloci: cluster %s" % idmc)
+            c = copy.deepcopy(list(current[idmc]))
 
-        n_loci = len(c)
-        if n_loci < 1000:
-            filtered, n_cluster = _iter_loci(c, clus_obj.clus, (clus_obj.loci, clus_obj.seq), filtered, n_cluster)
-        else:
-            large += 1
-            n_cluster += 1
-            _write_cluster(c, clus_obj.clus, clus_obj.loci, n_cluster, path)
-            filtered[n_cluster] = _add_complete_cluster(n_cluster, c, clus_obj.clus)
+            n_loci = len(c)
+            if n_loci < 1000:
+                filtered, n_cluster = _iter_loci(c, clus_obj.clus, (clus_obj.loci, clus_obj.seq), filtered, n_cluster)
+            else:
+                large += 1
+                n_cluster += 1
+                _write_cluster(c, clus_obj.clus, clus_obj.loci, n_cluster, path)
+                filtered[n_cluster] = _add_complete_cluster(n_cluster, c, clus_obj.clus)
     clus_obj.clus = filtered
 
     seqs = 0

--- a/seqcluster/libs/barchart.py
+++ b/seqcluster/libs/barchart.py
@@ -130,9 +130,9 @@ def createhtml(info,keys):
 #{"DB":"RNA","uni":15,"mul":4,"nocon":5}]
 #bar=["uni","mul","nocon"]
 
-#print createdata(info)
-#print addgraph("unique","uni","green")
-#print createchart(bar)
+#print(createdata(info))
+#print(addgraph("unique","uni","green"))
+#print(createchart(bar))
 
 
 

--- a/seqcluster/libs/expchart.py
+++ b/seqcluster/libs/expchart.py
@@ -83,9 +83,9 @@ def getExpDiv():
 #{"DB":"RNA","uni":15,"mul":4,"nocon":5}]
 #bar=["uni","mul","nocon"]
 
-#print createdata(info)
-#print addgraph("unique","uni","green")
-#print createchart(bar)
+#print(createdata(info))
+#print(addgraph("unique","uni","green"))
+#print(createchart(bar))
 
 
 

--- a/seqcluster/libs/report.py
+++ b/seqcluster/libs/report.py
@@ -44,19 +44,18 @@ def make_profile(data, out_dir, args):
     main_table = []
     header = ['id', 'ann']
     n = len(data[0])
-    bar = ProgressBar(maxval=n)
-    bar.start()
-    bar.update(0)
-    for itern, c in enumerate(data[0]):
-        bar.update(itern)
-        logger.debug("creating cluser: {}".format(c))
-        safe_dirs(os.path.join(out_dir, c))
-        valid, ann, pos_structure = _single_cluster(c, data, os.path.join(out_dir, c, "maps.tsv"), args)
-        data[0][c].update({'profile': pos_structure})
-        loci = data[0][c]['loci']
-        data[0][c]['precursor'] = {"seq": precursor_sequence(loci[0][0:5], args.ref)}
-        data[0][c]['precursor']["colors"] = _parse(data[0][c]['profile'], data[0][c]['precursor']["seq"])
-        data[0][c]['precursor'].update(run_rnafold(data[0][c]['precursor']['seq']))
+    with ProgressBar(maxval=n) as bar:
+        bar.update(0)
+        for itern, c in enumerate(data[0]):
+            bar.update(itern)
+            logger.debug("creating cluser: {}".format(c))
+            safe_dirs(os.path.join(out_dir, c))
+            valid, ann, pos_structure = _single_cluster(c, data, os.path.join(out_dir, c, "maps.tsv"), args)
+            data[0][c].update({'profile': pos_structure})
+            loci = data[0][c]['loci']
+            data[0][c]['precursor'] = {"seq": precursor_sequence(loci[0][0:5], args.ref)}
+            data[0][c]['precursor']["colors"] = _parse(data[0][c]['profile'], data[0][c]['precursor']["seq"])
+            data[0][c]['precursor'].update(run_rnafold(data[0][c]['precursor']['seq']))
 
     return data
 
@@ -123,9 +122,9 @@ def _single_cluster(c, data, out_file, args):
     valid, ann = 0, 0
     raw_file = None
     freq = defaultdict()
-    [freq.update({s.keys()[0]: s.values()[0]}) for s in data[0][c]['freq']]
-    names = [s.keys()[0] for s in data[0][c]['seqs']]
-    seqs = [s.values()[0] for s in data[0][c]['seqs']]
+    [freq.update({list(s.keys())[0]: list(s.values())[0]}) for s in data[0][c]['freq']]
+    names = [list(s.keys())[0] for s in data[0][c]['seqs']]
+    seqs = [list(s.values())[0] for s in data[0][c]['seqs']]
     loci = data[0][c]['loci']
 
     if loci[0][3] - loci[0][2] > 500:

--- a/seqcluster/make_clusters.py
+++ b/seqcluster/make_clusters.py
@@ -214,7 +214,7 @@ def _sum_by_samples(seqs_freq, samples_order):
     """
     Sum sequences of a metacluster by samples.
     """
-    n = len(seqs_freq[seqs_freq.keys()[0]].freq.keys())
+    n = len(seqs_freq[list(seqs_freq.keys())[0]].freq.keys())
     y = np.array([0] * n)
     for s in seqs_freq:
         x = seqs_freq[s].freq

--- a/seqcluster/methods/__init__.py
+++ b/seqcluster/methods/__init__.py
@@ -7,9 +7,9 @@ def read_cluster(data, id=1):
     """Read json cluster and populate as cluster class"""
     cl = cluster(1)
 
-    # seqs = [s.values()[0] for s in data['seqs']]
-    names = [s.keys()[0] for s in data['seqs']]
+    # seqs = [list(s.values())[0] for s in data['seqs']]
+    names = [list(s.keys())[0] for s in data['seqs']]
     cl.add_id_member(names, 1)
     freq = defaultdict()
-    [freq.update({s.keys()[0]: s.values()[0]}) for s in data['freq']]
+    [freq.update({list(s.keys())[0]: list(s.values())[0]}) for s in data['freq']]
 


### PR DESCRIPTION
Works off devel branch and adds few remaining fixes for tests to pass on
python 3 (with miRTop/mirtop#51 in place):

- Use progressbar2, supported on Python 2 and 3, instead of progressbar.
- Few remaining checks for list/iterator issues with keys
- Small cleanups for has_key and print statements