### PR TITLE
fix umi bug

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+- 1.2.9
+
+  * Fix bug where UMI is mistakenly detected in read names containing "ILLUMINA"
+
 - 1.2.8
 
   * Fix bug when detecting the end of the cluster due to big gaps in biopython function

--- a/seqcluster/libs/fastq.py
+++ b/seqcluster/libs/fastq.py
@@ -17,7 +17,7 @@ def collapse(in_file):
         line = handle.readline()
         while line:
             if line.startswith("@"):
-                if line.find("UMI") > -1:
+                if line.find("UMI_") > -1:
                     logger.info("Find UMI tags in read names, collapsing by UMI.")
                     return collapse_umi(in_file)
                 seq = handle.readline().strip()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt", "r") as f:
 
 
 setup(name='seqcluster',
-      version='1.2.8',
+      version='1.2.9',
       description='Small RNA-seq pipeline',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
tool mistakenly tries to identify a UMI when the read name contains the word "ILLUMINA". Changed search string from "UMI" to "UMI_" to fix this. 