### PR TITLE
s/l/mystats.py: migrate to scipy.stats.binomtest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pysam>=0.8.2.1
 biopython
 pybedtools>=0.6.8
-scipy>=0.15.1
+scipy>=1.7.0
 numpy
 nose>=1.3.0
 progressbar2

--- a/seqcluster/libs/mystats.py
+++ b/seqcluster/libs/mystats.py
@@ -8,6 +8,6 @@ def up_threshold(x, s, p):
     below cutoff"""
     if 1.0 * x/s >= p:
         return True
-    elif stat.binom_test(x, s, p) > 0.01:
+    elif stat.binomtest(int(x), int(s), p).pvalue > 0.01:
         return True
     return False

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt", "r") as f:
 
 
 setup(name='seqcluster',
-      version='1.2.9',
+      version='1.2.10',
       description='Small RNA-seq pipeline',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
[scipy.stats.binom_test] is deprecated and removed in scipy 1.12.0. It is replaced by [scipy.stats.binomtest], which has slightly different signature.  This change accomodates for the new function with minimal change.

This was initially identified in [Debian bug #1076912].

[scipy.stats.binom_test]: https://docs.scipy.org/doc/scipy-1.11.0/reference/generated/scipy.stats.binom_test.html
[scipy.stats.binomtest]: https://docs.scipy.org/doc/scipy-1.11.0/reference/generated/scipy.stats.binomtest.html
[Debian bug #1076912]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076912